### PR TITLE
feat: switch recipes to ingredient_groups with grouped UI display

### DIFF
--- a/docs/superpowers/specs/2026-03-28-ingredient-groups-design.md
+++ b/docs/superpowers/specs/2026-03-28-ingredient-groups-design.md
@@ -1,0 +1,88 @@
+# Ingredient Groups Migration
+
+**Date:** 2026-03-28
+**Status:** Draft
+
+## Summary
+
+Replace the flat `ingredients: string[]` field on recipes with `ingredientGroups: IngredientGroup[]` to support grouped ingredients (e.g. "Sås", "Potatismos"). This affects types, data fetching, matching logic, UI rendering, cooking mode, and two Supabase RPC functions.
+
+## Data Structure
+
+The `ingredient_groups` column in the `recipes` table stores:
+
+```json
+[
+  { "name": null, "items": ["1 dl olivolja", "salt"] },
+  { "name": "Sås", "items": ["2 dl grädde", "1 msk smör"] }
+]
+```
+
+- `name: null` means ungrouped items (render without header)
+- `name: string` renders as a section header
+
+TypeScript type:
+
+```ts
+export interface IngredientGroup {
+  name: string | null
+  items: string[]
+}
+```
+
+## Changes
+
+### 1. Types (`src/types/index.ts`)
+
+- Add `IngredientGroup` interface
+- Replace `ingredients: string[]` with `ingredientGroups: IngredientGroup[]` on `Recipe`
+- Remove `ingredients` entirely
+
+### 2. Recipes lib (`src/lib/recipes.ts`)
+
+- `RecipeRow`: replace `ingredients` with `ingredient_groups`
+- `mapRecipe()`: map `ingredient_groups` → `ingredientGroups`
+- All `.select()` queries: replace `ingredients` with `ingredient_groups`
+
+### 3. Recipe matching (`src/lib/recipeMatching.ts`)
+
+- Add helper: `getAllIngredients(recipe)` — flattens all groups' items into a single `string[]`
+- `matchRecipe()`: use `getAllIngredients()` instead of `recipe.ingredients`
+- Matching logic is group-agnostic — groups only matter for display
+
+### 4. RecipesPage UI (`src/pages/RecipesPage.tsx`)
+
+#### Recipe card (list view)
+
+- Score badge: count total items across all groups using `getAllIngredients()`
+
+#### Recipe modal — ingredient view (not cooking)
+
+- Render each group:
+  - If `name` is not null → show group name as a `Text fw={600}` subheader
+  - List items with ✓/✗ icons (same as today, but per group)
+- "Ingredienser (3/8 hemma)" header counts across all groups
+
+#### Recipe modal — cooking mode
+
+- Show **all ingredients grouped** (not just matched inventory items)
+- Each ingredient gets a checkbox
+- Matched ingredients are pre-checked
+- Unmatched ingredients are unchecked (user can still check them off as a cooking checklist)
+- "Bekräfta" still only decrements inventory for items that match actual inventory entries
+- Group headers shown in cooking mode too
+
+### 5. Supabase RPC functions (SQL migration)
+
+Two functions need updating to extract ingredient text from `ingredient_groups` JSONB instead of `ingredients`:
+
+- `search_recipes` — full-text search
+- `match_recipes_by_ingredients` — ingredient matching
+
+See `supabase/migrations/2026-03-28-ingredient-groups-rpc.sql` for the migration.
+
+## Out of scope
+
+- Migrating old `ingredients` data to `ingredient_groups` (assumed already done by scraper)
+- Dropping the `ingredients` column from DB (can be done later)
+- Changes to the scraper

--- a/src/lib/recipeMatching.ts
+++ b/src/lib/recipeMatching.ts
@@ -7,6 +7,11 @@ export interface RecipeMatch {
   score: number // 0–1
 }
 
+/** Flattens all ingredient groups into a single string array */
+export function getAllIngredients(recipe: Recipe): string[] {
+  return recipe.ingredientGroups.flatMap((g) => g.items)
+}
+
 /** Normalizes an ingredient name for fuzzy comparison */
 export function normalizeIngredient(name: string): string {
   return name.toLowerCase().trim().replace(/\s+/g, ' ')
@@ -23,8 +28,9 @@ export function ingredientsMatch(a: string, b: string): boolean {
 export function matchRecipe(recipe: Recipe, inventoryNames: string[]): RecipeMatch {
   const matched: string[] = []
   const missing: string[] = []
+  const allIngredients = getAllIngredients(recipe)
 
-  for (const ingredient of recipe.ingredients) {
+  for (const ingredient of allIngredients) {
     const found = inventoryNames.some((inv) => ingredientsMatch(ingredient, inv))
     if (found) {
       matched.push(ingredient)
@@ -33,7 +39,7 @@ export function matchRecipe(recipe: Recipe, inventoryNames: string[]): RecipeMat
     }
   }
 
-  const total = recipe.ingredients.length
+  const total = allIngredients.length
   const score = total > 0 ? matched.length / total : 0
 
   return { recipe, matched, missing, score }

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -1,13 +1,18 @@
 import { supabase } from './supabase'
 import type { Recipe } from '../types'
 
+interface IngredientGroupRow {
+  name: string | null
+  items: string[]
+}
+
 interface RecipeRow {
   id: number
   url: string
   slug: string | null
   name: string | null
   description: string | null
-  ingredients: string[]
+  ingredient_groups: IngredientGroupRow[]
   instructions: string[]
   image_urls: string[]
   cook_time: string | null
@@ -23,7 +28,7 @@ function mapRecipe(row: RecipeRow): Recipe {
     slug: row.slug,
     name: row.name,
     description: row.description,
-    ingredients: row.ingredients ?? [],
+    ingredientGroups: row.ingredient_groups ?? [],
     instructions: row.instructions ?? [],
     imageUrls: row.image_urls ?? [],
     cookTime: row.cook_time,
@@ -44,7 +49,7 @@ export async function getRecipeById(id: number): Promise<Recipe | null> {
   const { data, error } = await supabase
     .from('recipes')
     .select(
-      'id, url, slug, name, description, ingredients, instructions, image_urls, cook_time, prep_time, total_time, servings'
+      'id, url, slug, name, description, ingredient_groups, instructions, image_urls, cook_time, prep_time, total_time, servings'
     )
     .eq('id', id)
     .single()
@@ -56,7 +61,7 @@ export async function getRecipeBySlug(slug: string): Promise<Recipe | null> {
   const { data, error } = await supabase
     .from('recipes')
     .select(
-      'id, url, slug, name, description, ingredients, instructions, image_urls, cook_time, prep_time, total_time, servings'
+      'id, url, slug, name, description, ingredient_groups, instructions, image_urls, cook_time, prep_time, total_time, servings'
     )
     .eq('slug', slug)
     .single()
@@ -68,7 +73,7 @@ export async function getRecentRecipes(limit = 20): Promise<Recipe[]> {
   const { data, error } = await supabase
     .from('recipes')
     .select(
-      'id, url, slug, name, description, ingredients, instructions, image_urls, cook_time, prep_time, total_time, servings'
+      'id, url, slug, name, description, ingredient_groups, instructions, image_urls, cook_time, prep_time, total_time, servings'
     )
     .not('name', 'is', null)
     .not('image_urls', 'eq', '[]')

--- a/src/pages/RecipesPage.tsx
+++ b/src/pages/RecipesPage.tsx
@@ -30,8 +30,20 @@ import {
 } from '@tabler/icons-react'
 import { useInventoryStore } from '../store/inventoryStore'
 import { suggestRecipes, searchRecipes, getRecentRecipes } from '../lib/recipes'
-import { matchRecipes, ingredientsMatch } from '../lib/recipeMatching'
+import { matchRecipes, ingredientsMatch, getAllIngredients } from '../lib/recipeMatching'
 import type { RecipeMatch } from '../lib/recipeMatching'
+import type { IngredientGroup } from '../types'
+
+/** Merge all null-named groups into one, keeping named groups as-is */
+function mergeUnnamedGroups(groups: IngredientGroup[]): IngredientGroup[] {
+  const unnamed = groups.filter((g) => !g.name)
+  const named = groups.filter((g) => g.name)
+  const merged: IngredientGroup[] = []
+  if (unnamed.length > 0) {
+    merged.push({ name: null, items: unnamed.flatMap((g) => g.items) })
+  }
+  return [...merged, ...named]
+}
 
 const FAVORITES_KEY = 'lagret:favorite-recipes'
 
@@ -128,15 +140,34 @@ export function RecipesPage() {
     : []
 
   const openCook = () => {
-    setCookChecked(new Set(matchedInventoryItems.map((i) => i.id)))
+    if (!selected) return
+    const preChecked = new Set<string>()
+    mergeUnnamedGroups(selected.recipe.ingredientGroups).forEach((group, gi) => {
+      group.items.forEach((ingredient, i) => {
+        const hasInInventory = matchedInventoryItems.some((inv) =>
+          ingredientsMatch(ingredient, inv.name)
+        )
+        if (hasInInventory) preChecked.add(`${gi}-${i}`)
+      })
+    })
+    setCookChecked(preChecked)
     setCookDone(false)
     setCooking(true)
   }
 
   const handleCook = async () => {
+    if (!selected) return
+    const toDecrement = new Set<string>()
+    mergeUnnamedGroups(selected.recipe.ingredientGroups).forEach((group, gi) => {
+      group.items.forEach((ingredient, i) => {
+        if (!cookChecked.has(`${gi}-${i}`)) return
+        const inv = matchedInventoryItems.find((it) => ingredientsMatch(ingredient, it.name))
+        if (inv) toDecrement.add(inv.id)
+      })
+    })
     await Promise.all(
       matchedInventoryItems
-        .filter((i) => cookChecked.has(i.id))
+        .filter((i) => toDecrement.has(i.id))
         .map((i) => updateItem(i.id, { quantity: Math.max(0, i.quantity - 1) }))
     )
     setCookDone(true)
@@ -218,7 +249,7 @@ export function RecipesPage() {
                         </Badge>
                       )}
                       <Badge size="xs" color={scoreColor(m.score)} data-testid="score-badge">
-                        {m.matched.length}/{m.recipe.ingredients.length} ingredienser
+                        {m.matched.length}/{getAllIngredients(m.recipe).length} ingredienser
                       </Badge>
                     </Group>
                     {m.missing.length > 0 && (
@@ -272,8 +303,8 @@ export function RecipesPage() {
               <>
                 <Group justify="space-between">
                   <Text fw={600}>
-                    Ingredienser ({selected.matched.length}/{selected.recipe.ingredients.length}{' '}
-                    hemma)
+                    Ingredienser ({selected.matched.length}/
+                    {getAllIngredients(selected.recipe).length} hemma)
                   </Text>
                   {matchedInventoryItems.length > 0 && (
                     <Button
@@ -286,27 +317,36 @@ export function RecipesPage() {
                     </Button>
                   )}
                 </Group>
-                <List>
-                  {selected.recipe.ingredients.map((ingredient, i) => {
-                    const have = selected.matched.some(
-                      (m) => m.toLowerCase() === ingredient.toLowerCase()
-                    )
-                    return (
-                      <List.Item
-                        key={i}
-                        icon={
-                          <ThemeIcon color={have ? 'green' : 'red'} size={16} radius="xl">
-                            <span style={{ fontSize: 10 }}>{have ? '✓' : '✗'}</span>
-                          </ThemeIcon>
-                        }
-                      >
-                        <Text size="sm" c={have ? undefined : 'dimmed'}>
-                          {ingredient}
-                        </Text>
-                      </List.Item>
-                    )
-                  })}
-                </List>
+                {mergeUnnamedGroups(selected.recipe.ingredientGroups).map((group, gi) => (
+                  <Stack key={gi} gap={4}>
+                    {group.name && (
+                      <Text fw={600} size="sm" mt={gi > 0 ? 'xs' : 0}>
+                        {group.name}
+                      </Text>
+                    )}
+                    <List>
+                      {group.items.map((ingredient, i) => {
+                        const have = selected.matched.some(
+                          (m) => m.toLowerCase() === ingredient.toLowerCase()
+                        )
+                        return (
+                          <List.Item
+                            key={i}
+                            icon={
+                              <ThemeIcon color={have ? 'green' : 'red'} size={16} radius="xl">
+                                <span style={{ fontSize: 10 }}>{have ? '✓' : '✗'}</span>
+                              </ThemeIcon>
+                            }
+                          >
+                            <Text size="sm" c={have ? undefined : 'dimmed'}>
+                              {ingredient}
+                            </Text>
+                          </List.Item>
+                        )
+                      })}
+                    </List>
+                  </Stack>
+                ))}
                 <Divider />
                 <Text fw={600}>Instruktioner</Text>
                 <List type="ordered">
@@ -323,34 +363,50 @@ export function RecipesPage() {
               </Alert>
             ) : (
               <>
-                <Text fw={600}>Vilka varor använde du?</Text>
+                <Text fw={600}>Bocka av ingredienser du använt</Text>
                 <Text size="sm" c="dimmed">
-                  Bocka av det du använt — antalet minskas med 1.
+                  Varor från lagret minskas med 1 st.
                 </Text>
-                <Stack gap="xs">
-                  {matchedInventoryItems.map((inv) => (
-                    <Checkbox
-                      key={inv.id}
-                      checked={cookChecked.has(inv.id)}
-                      onChange={() =>
-                        setCookChecked((prev) => {
-                          const next = new Set(prev)
-                          if (next.has(inv.id)) next.delete(inv.id)
-                          else next.add(inv.id)
-                          return next
-                        })
-                      }
-                      label={
-                        <Text size="sm">
-                          {inv.name}{' '}
-                          <Text span c="dimmed">
-                            ({inv.quantity} {inv.unit})
-                          </Text>
-                        </Text>
-                      }
-                    />
-                  ))}
-                </Stack>
+                {mergeUnnamedGroups(selected.recipe.ingredientGroups).map((group, gi) => (
+                  <Stack key={gi} gap="xs">
+                    {group.name && (
+                      <Text fw={600} size="sm" mt={gi > 0 ? 'xs' : 0}>
+                        {group.name}
+                      </Text>
+                    )}
+                    {group.items.map((ingredient, i) => {
+                      const invItem = matchedInventoryItems.find((inv) =>
+                        ingredientsMatch(ingredient, inv.name)
+                      )
+                      const key = `${gi}-${i}`
+                      return (
+                        <Checkbox
+                          key={key}
+                          checked={cookChecked.has(key)}
+                          onChange={() =>
+                            setCookChecked((prev) => {
+                              const next = new Set(prev)
+                              if (next.has(key)) next.delete(key)
+                              else next.add(key)
+                              return next
+                            })
+                          }
+                          label={
+                            <Text size="sm">
+                              {ingredient}
+                              {invItem && (
+                                <Text span c="dimmed">
+                                  {' '}
+                                  ({invItem.quantity} {invItem.unit} i lager)
+                                </Text>
+                              )}
+                            </Text>
+                          }
+                        />
+                      )
+                    })}
+                  </Stack>
+                ))}
                 <Group>
                   <Button variant="subtle" color="gray" onClick={() => setCooking(false)}>
                     Avbryt

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,13 +24,18 @@ export interface InventoryItem {
   updatedAt: string
 }
 
+export interface IngredientGroup {
+  name: string | null
+  items: string[]
+}
+
 export interface Recipe {
   id: number
   url: string
   slug: string | null
   name: string | null
   description: string | null
-  ingredients: string[]
+  ingredientGroups: IngredientGroup[]
   instructions: string[]
   imageUrls: string[]
   cookTime: string | null

--- a/supabase/migrations/2026-03-28-ingredient-groups-rpc.sql
+++ b/supabase/migrations/2026-03-28-ingredient-groups-rpc.sql
@@ -1,0 +1,59 @@
+-- Migration: Update RPC functions to use ingredient_groups instead of ingredients
+-- Run this in Supabase SQL Editor
+
+-- 1. search_recipes: full-text search across recipe name, description, and ingredient items
+CREATE OR REPLACE FUNCTION search_recipes(query text, lim int DEFAULT 20)
+RETURNS SETOF recipes
+LANGUAGE sql STABLE
+AS $$
+  SELECT r.*
+  FROM recipes r
+  WHERE r.name IS NOT NULL
+    AND r.image_urls IS NOT NULL
+    AND jsonb_array_length(r.image_urls) > 0
+    AND (
+      r.name ILIKE '%' || query || '%'
+      OR r.description ILIKE '%' || query || '%'
+      OR EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(r.ingredient_groups) AS grp,
+             jsonb_array_elements_text(grp -> 'items') AS item
+        WHERE item ILIKE '%' || query || '%'
+      )
+    )
+  ORDER BY
+    CASE WHEN r.name ILIKE '%' || query || '%' THEN 0 ELSE 1 END,
+    r.id DESC
+  LIMIT lim;
+$$;
+
+-- 2. match_recipes_by_ingredients: find recipes that use any of the given ingredients
+CREATE OR REPLACE FUNCTION match_recipes_by_ingredients(
+  search_ingredients text[],
+  lim int DEFAULT 20
+)
+RETURNS TABLE(id int, name text, slug text, image_urls jsonb, match_count bigint)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    r.id,
+    r.name,
+    r.slug,
+    r.image_urls,
+    COUNT(DISTINCT lower(item)) AS match_count
+  FROM recipes r,
+       jsonb_array_elements(r.ingredient_groups) AS grp,
+       jsonb_array_elements_text(grp -> 'items') AS item
+  WHERE r.name IS NOT NULL
+    AND r.image_urls IS NOT NULL
+    AND jsonb_array_length(r.image_urls) > 0
+    AND EXISTS (
+      SELECT 1
+      FROM unnest(search_ingredients) AS si
+      WHERE lower(item) LIKE '%' || lower(si) || '%'
+         OR lower(si) LIKE '%' || lower(item) || '%'
+    )
+  GROUP BY r.id, r.name, r.slug, r.image_urls
+  ORDER BY match_count DESC, r.id DESC
+  LIMIT lim;
+$$;


### PR DESCRIPTION
Replace flat ingredients array with ingredientGroups supporting named sections (e.g. "Sås", "Fyllning"). Multiple unnamed groups are merged into one flat list. Cooking mode shows all ingredients as a checklist.